### PR TITLE
Add `standard_metadata` to `mark_to_drop` call

### DIFF
--- a/switch.p4
+++ b/switch.p4
@@ -159,7 +159,7 @@ control MyIngress(inout headers hdr,
     register<util_t>((bit<32>) NUM_TORS) min_path_util;
 
     action drop() {
-        mark_to_drop();
+        mark_to_drop(standard_metadata);
     }
 
     /******************************************************/


### PR DESCRIPTION
This is required by the v1model architecture.